### PR TITLE
Add support for Digilent HS2 cable.

### DIFF
--- a/urjtag/src/tap/cable/generic_usbconn_list.h
+++ b/urjtag/src/tap/cable/generic_usbconn_list.h
@@ -64,6 +64,7 @@ _URJ_USB_FTDX(usbjtagrs232)
 _URJ_USB_FTDX(usbscarab2)
 _URJ_USB_FTDX(usbtojtagif)
 _URJ_USB_FTDX(digilenths1)
+_URJ_USB_FTDX(digilenths2)
 _URJ_USB_FTDX(ft4232)
 #endif
 #ifdef ENABLE_CABLE_USBBLASTER

--- a/urjtag/src/tap/cable_list.h
+++ b/urjtag/src/tap/cable_list.h
@@ -66,6 +66,7 @@ _URJ_CABLE(ft2232_usbjtagrs232)
 _URJ_CABLE(ft2232_usbscarab2)
 _URJ_CABLE(ft2232_usbtojtagif)
 _URJ_CABLE(ft2232_digilenths1)
+_URJ_CABLE(ft2232_digilenths2)
 _URJ_CABLE(ft2232_ft4232)
 #endif
 #ifdef ENABLE_CABLE_GPIO


### PR DESCRIPTION
2-wire JTAG is capable by the HS2 hardware but not supported here.